### PR TITLE
sideEffects:false to package.json for tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "version": "0.4.0",
   "name": "@icons/material",
   "main": "index.js",
+  "sideEffects": false,
   "scripts": {
     "transform": "node transform.js",
     "build": "babel icons -d .",


### PR DESCRIPTION
Using named exports from this package can lead to all icons being imported into a consuming app's bundle. Adding `"sideEffects": false` to the `package.json` enables proper tree-shaking in webpack 4 and above.

https://webpack.js.org/guides/tree-shaking/